### PR TITLE
Toy Simple Buffer Manager

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -21,7 +21,7 @@ file(GLOB_RECURSE INCLUDE_H
 set(
     INCLUDE_H
     ${CMAKE_SOURCE_DIR}/src/include
-    ${CMAKE_SOURCE_DIR}/test/unit/include
+    # ${CMAKE_SOURCE_DIR}/test/unit/include
     ${CMAKE_SOURCE_DIR}    
 )
 

--- a/src/include/utils/buffermanager.h
+++ b/src/include/utils/buffermanager.h
@@ -1,0 +1,74 @@
+using namespace std;
+#include <cstddef>
+#include <cstdint>
+#include <exception>
+#include <vector>
+#include <map>
+#include <memory>
+
+#include "common/macros.h"
+
+namespace buzzdb {
+
+class BufferFrame {
+private:
+    friend class BufferManager;
+
+    uint64_t page_number;
+    bool dirty_bit;
+    int counter;
+    vector<uint64_t> data; 
+    bool exclusive;
+
+public:
+    //Constructor
+    BufferFrame(uint64_t page_number, uint64_t frame_size, vector<uint64_t> data);
+    
+    char* get_data();
+};
+
+
+class buffer_full_error
+: public std::exception {
+public:
+    const char* what() const noexcept override {
+        return "buffer is full";
+    }
+};
+
+
+class BufferManager {
+private:
+    
+    vector<BufferFrame> fifo_queue;
+    map<uint64_t, int> fifo_map;
+
+    size_t page_size;
+    size_t page_count;
+
+public:
+
+    BufferManager(size_t page_size, size_t page_count);
+
+    ~BufferManager();
+
+
+    BufferFrame& fix_page(uint64_t page_id, bool exclusive);
+
+    void unfix_page(BufferFrame& page, bool is_dirty);
+
+
+    static constexpr uint16_t get_segment_id(uint64_t page_id) {
+        return page_id >> 48;
+    }
+
+
+    static constexpr uint64_t get_segment_page_id(uint64_t page_id) {
+        return page_id & ((1ull << 48) - 1);
+    }
+
+    std::vector<uint64_t> get_fifo_list() const;
+};
+
+
+}  

--- a/src/include/utils/common/defer.h
+++ b/src/include/utils/common/defer.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <functional>
+
+namespace buzzdb {
+
+struct Defer {
+  /// The deferred function.
+  std::function<void()> fn;
+
+  /// Constructor.
+  explicit Defer(std::function<void()> fn) : fn(std::move(fn)) {}
+
+  /// Destructor.
+  /// Calls the deferred function.
+  ~Defer() { fn(); }
+
+  /// Runs the deferred funciton.
+  void run() {
+    fn();
+    fn = []() {};
+  }
+};
+
+}  // namespace buzzdb

--- a/src/include/utils/common/error.h
+++ b/src/include/utils/common/error.h
@@ -1,0 +1,152 @@
+#pragma once
+
+#include <stdexcept>
+#include <string>
+
+#include <cxxabi.h>
+#include <errno.h>
+#include <execinfo.h>
+#include <signal.h>
+
+namespace buzzdb {
+
+enum class ExceptionType {
+  INVALID_EXCEPTION = 0,  // invalid type
+
+  NOT_IMPLEMENTED_EXCEPTION = 1,
+  SCHEMA_PARSING_EXCEPTION = 2,
+
+};
+
+class Exception : public std::runtime_error {
+ public:
+  Exception(ExceptionType exception_type)
+      : std::runtime_error(""), type(exception_type) {
+    exception_message_ =
+        "Exception Type :: " + ExceptionTypeToString(exception_type);
+  }
+
+  Exception(std::string message)
+      : std::runtime_error(message), type(ExceptionType::INVALID_EXCEPTION) {
+    exception_message_ = "Message :: " + message;
+  }
+
+  Exception(ExceptionType exception_type, std::string message)
+      : std::runtime_error(message), type(exception_type) {
+    exception_message_ =
+        "Exception Type :: " + ExceptionTypeToString(exception_type) +
+        "\nMessage :: " + message;
+  }
+
+  std::string GetMessage() { return exception_message_; }
+
+  std::string ExceptionTypeToString(ExceptionType type) {
+    switch (type) {
+      case ExceptionType::INVALID_EXCEPTION:
+        return "Invalid";
+      case ExceptionType::NOT_IMPLEMENTED_EXCEPTION:
+        return "Not Implemented";
+      case ExceptionType::SCHEMA_PARSING_EXCEPTION:
+        return "Schema Parsing";
+
+      default:
+        return "Unknown";
+    }
+  }
+
+  // Based on :: http://panthema.net/2008/0901-stacktrace-demangled/
+  static void PrintStackTrace(FILE *out = ::stderr,
+                              unsigned int max_frames = 63) {
+    ::fprintf(out, "Stack Trace:\n");
+
+    /// storage array for stack trace address data
+    void *addrlist[max_frames + 1];
+
+    /// retrieve current stack addresses
+    int addrlen = backtrace(addrlist, max_frames + 1);
+
+    if (addrlen == 0) {
+      ::fprintf(out, "  <empty, possibly corrupt>\n");
+      return;
+    }
+
+    /// resolve addresses into strings containing "filename(function+address)",
+    char **symbol_list = backtrace_symbols(addrlist, addrlen);
+
+    /// allocate string which will be filled with the demangled function name
+    size_t func_name_size = 1024;
+    std::unique_ptr<char> func_name(new char[func_name_size]);
+
+    /// iterate over the returned symbol lines. skip the first, it is the
+    /// address of this function.
+    for (int i = 1; i < addrlen; i++) {
+      char *begin_name = 0, *begin_offset = 0, *end_offset = 0;
+
+      /// find parentheses and +address offset surrounding the mangled name:
+      /// ./module(function+0x15c) [0x8048a6d]
+      for (char *p = symbol_list[i]; *p; ++p) {
+        if (*p == '(')
+          begin_name = p;
+        else if (*p == '+')
+          begin_offset = p;
+        else if (*p == ')' && begin_offset) {
+          end_offset = p;
+          break;
+        }
+      }
+
+      if (begin_name && begin_offset && end_offset &&
+          begin_name < begin_offset) {
+        *begin_name++ = '\0';
+        *begin_offset++ = '\0';
+        *end_offset = '\0';
+
+        /// mangled name is now in [begin_name, begin_offset) and caller
+        /// offset in [begin_offset, end_offset). now apply  __cxa_demangle():
+        int status;
+        char *ret = abi::__cxa_demangle(begin_name, func_name.get(),
+                                        &func_name_size, &status);
+        if (status == 0) {
+          func_name.reset(ret);  // use possibly realloc()-ed string
+          ::fprintf(out, "  %s : %s+%s\n", symbol_list[i], func_name.get(),
+                    begin_offset);
+        } else {
+          /// demangling failed. Output function name as a C function with
+          /// no arguments.
+          ::fprintf(out, "  %s : %s()+%s\n", symbol_list[i], begin_name,
+                    begin_offset);
+        }
+      } else {
+        /// couldn't parse the line ? print the whole line.
+        ::fprintf(out, "  %s\n", symbol_list[i]);
+      }
+    }
+  }
+
+  friend std::ostream &operator<<(std::ostream &os, const Exception &e);
+
+ private:
+  // type
+  ExceptionType type;
+  std::string exception_message_;
+};
+
+//===--------------------------------------------------------------------===//
+// Derived classes
+//===--------------------------------------------------------------------===//
+
+class NotImplementedException : public Exception {
+ public:
+  NotImplementedException()
+      : Exception(ExceptionType::NOT_IMPLEMENTED_EXCEPTION) {}
+};
+
+class SchemaParseException : public Exception {
+  SchemaParseException() = delete;
+
+ public:
+  SchemaParseException(std::string msg)
+      : Exception(ExceptionType::SCHEMA_PARSING_EXCEPTION, msg) {}
+};
+
+}  // namespace buzzdb

--- a/src/include/utils/common/macros.h
+++ b/src/include/utils/common/macros.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include<limits> 
+
+namespace buzzdb {
+
+#define UNUSED_ATTRIBUTE __attribute__((unused))
+
+constexpr uint64_t INVALID_PAGE_ID = std::numeric_limits<uint64_t>::max();
+
+constexpr uint64_t INVALID_FRAME_ID = std::numeric_limits<uint64_t>::max();
+
+constexpr uint64_t INVALID_NODE_ID = std::numeric_limits<uint64_t>::max();
+
+constexpr size_t REGISTER_SIZE = 16 + 1;  // null delimiter
+
+}  // namespace buzzdb

--- a/src/include/utils/storage/file.h
+++ b/src/include/utils/storage/file.h
@@ -1,0 +1,72 @@
+#pragma once
+
+#include <cstdint>
+#include <memory>
+
+namespace buzzdb {
+
+///
+/// Block-wise file API for C++.
+///
+class File {
+ public:
+  /// File mode (read or write)
+  enum Mode { READ, WRITE };
+
+  virtual ~File() = default;
+
+  /// Returns the `Mode` this file was opened with.
+  virtual Mode get_mode() const = 0;
+
+  /// Returns the current size of the file in bytes.
+  /// Is not thread-safe w.r.t concurrent calls to `resize()`.
+  virtual size_t size() const = 0;
+
+  /// Resizes the file to `new_size`. If `new_size` is smaller than `size()`,
+  /// the file is cut off at the end. Otherwise zero bytes are appended at
+  /// the end.
+  /// Is not thread-safe.
+  virtual void resize(size_t new_size) = 0;
+
+  /// Reads a block of the file. `offset + size` must not be larger than
+  /// `size()`.
+  /// Is thread-safe w.r.t concurrent calls to `read_block()` and
+  /// `write_block()`.
+  /// @param[in]  offset The offset in the file from which the block should
+  ///                    be read.
+  /// @param[in]  size   The size of the block.
+  /// @param[out] block  A pointer to memory where the block is written to.
+  ///                    Must be able to hold at least `size` bytes.
+  virtual void read_block(size_t offset, size_t size, char* block) = 0;
+
+  /// Reads a block of the file and returns it.
+  std::unique_ptr<char[]> read_block(size_t offset, size_t size) {
+    auto block = std::make_unique<char[]>(size);
+    read_block(offset, size, block.get());
+    return block;
+  }
+
+  /// Writes a block to the file. `offset + size` must not be larger than
+  /// `size()`. If you want to write past the end of the file, use
+  /// `resize()` first.
+  /// This function must not be used when the file was opened in `READ` mode.
+  /// Is thread-safe w.r.t concurrent calls to `read_block()` and
+  /// `write_block()`.
+  /// @param[in] block  A pointer to memory that will be written to the
+  ///                   file. Must hold at least `size` bytes.
+  /// @param[in] offset The offset in the file at which the block should be
+  ///                   written.
+  /// @param[in] size   The size of the block.
+  virtual void write_block(const char* block, size_t offset, size_t size) = 0;
+
+  /// Opens a file with the given mode. Existing files are never overwritten.
+  /// @param[in] filename Path to the file.
+  /// @param[in] mode     `Mode` that should be used to open the file.
+  static std::unique_ptr<File> open_file(const char* filename, Mode mode);
+
+  /// Opens a temporary file in `WRITE` mode. The file will be deleted
+  /// automatically after use.
+  static std::unique_ptr<File> make_temporary_file();
+};
+
+}  // namespace buzzdb

--- a/src/include/utils/storage/test_file.h
+++ b/src/include/utils/storage/test_file.h
@@ -1,0 +1,41 @@
+#pragma once
+
+#include <vector>
+
+#include "utils/storage/file.h"
+
+namespace buzzdb {
+
+class TestFile : public File {
+ private:
+  Mode mode;
+  std::vector<char> file_content;
+
+ public:
+  explicit TestFile(Mode mode = WRITE) : mode(mode) {}
+
+  explicit TestFile(std::vector<char>&& file_content, Mode mode = READ)
+      : mode(mode), file_content(std::move(file_content)) {}
+
+  TestFile(const TestFile&) = default;
+  TestFile(TestFile&&) = default;
+
+  ~TestFile() override = default;
+
+  TestFile& operator=(const TestFile&) = default;
+  TestFile& operator=(TestFile&&) = default;
+
+  std::vector<char>& get_content() { return file_content; }
+
+  Mode get_mode() const override;
+
+  size_t size() const override;
+
+  void resize(size_t new_size) override;
+
+  void read_block(size_t offset, size_t size, char* block);
+
+  void write_block(const char* block, size_t offset, size_t size);
+};
+
+}  // namespace buzzdb

--- a/src/utils/buffermanager.cc
+++ b/src/utils/buffermanager.cc
@@ -1,0 +1,152 @@
+#include <cassert>
+#include <iostream>
+#include <string>
+
+#include "utils/buffermanager.h"
+#include "utils/storage/file.h"
+
+namespace buzzdb {
+
+BufferFrame::BufferFrame(uint64_t page_number, uint64_t frame_size, vector<uint64_t> data){
+    this->page_number = page_number;
+    this->dirty_bit = false;
+    this->counter = 1;
+    this->data = data;
+    if (this->data.size() == 0) {
+        this->data.resize(frame_size / sizeof(uint64_t));
+    }
+    this->exclusive = true;
+}
+
+char* BufferFrame::get_data() {
+
+    auto data = reinterpret_cast<char *>(this->data.data());
+    return data;
+}
+
+
+BufferManager::BufferManager(size_t page_size, size_t page_count) {
+    this->page_size = page_size;
+    this->page_count = page_count;
+}
+
+
+BufferManager::~BufferManager() {
+
+    for (BufferFrame frame : fifo_queue){
+        if(frame.dirty_bit == true){
+            string file_name = to_string(BufferManager::get_segment_id(frame.page_number));
+            const char* filename = file_name.c_str();
+            auto file = File::open_file(filename, File::WRITE);
+            uint64_t offSet = get_segment_page_id(frame.page_number) * page_size;
+            file->write_block(reinterpret_cast<char *>(frame.data.data()), offSet, page_size);
+        }
+    }
+
+}
+
+
+BufferFrame& BufferManager::fix_page(uint64_t page_id, bool exclusive) {
+
+    //Exists in fifo 
+    if (fifo_map.count(page_id) != 0){
+
+        int place_in_queue = fifo_map[page_id];
+
+        BufferFrame current_frame = fifo_queue[place_in_queue];
+        current_frame.counter += 1;
+        current_frame.exclusive = exclusive;
+        fifo_map.clear();
+
+        return fifo_queue[place_in_queue];
+    }
+    //does not exist fifo and we have memory left
+    else if (fifo_queue.size() < page_count){
+        vector<uint64_t> data;
+        data.resize(page_size/sizeof(uint64_t));
+
+        string file_name = to_string(BufferManager::get_segment_id(page_id));
+        const char* filename = file_name.c_str();
+        auto file = File::open_file(filename, File::WRITE);
+        uint64_t offSet = BufferManager::get_segment_page_id(page_id) * page_size;
+        file->read_block(offSet, page_size, reinterpret_cast<char *>(data.data()));
+
+        BufferFrame current_frame(page_id, this->page_size, data);
+        current_frame.exclusive = exclusive;
+        int new_position = fifo_queue.size();
+
+        fifo_queue.push_back(current_frame);
+        fifo_map[current_frame.page_number] = new_position;
+
+        return fifo_queue.back();
+    } 
+    else {
+
+        //check fifo for free slot aka counter = 0
+        int index = -1;
+        for (size_t i = 0; i < fifo_queue.size(); i++){
+            if (fifo_queue[i].counter == 0){
+                index = i;
+                break;
+            }
+        }
+        
+        //if a counter = 0 was found to evict, we will evict it and add the page to fifo
+        if (index != -1){
+
+            BufferFrame frame_to_evict = fifo_queue[index];
+            if (frame_to_evict.dirty_bit == true){
+                string file_name = to_string(BufferManager::get_segment_id(frame_to_evict.page_number));
+                const char* filename = file_name.c_str();
+                auto file = File::open_file(filename, File::WRITE);
+                uint64_t offset = get_segment_page_id(frame_to_evict.page_number) * page_size;
+                file->write_block(reinterpret_cast<char *>(frame_to_evict.data.data()), offset, page_size);
+            }
+            fifo_queue.erase(fifo_queue.begin() + index);
+            fifo_map.clear();
+            for (size_t i = 0; i < fifo_queue.size(); i++){
+                fifo_map[fifo_queue[i].page_number] = i;
+            }
+            //get data from disk and add it to fifo queue
+
+            vector<uint64_t> data;
+            data.resize(page_size/sizeof(uint64_t));
+            string file_name = to_string(BufferManager::get_segment_id(page_id));
+            const char* filename = file_name.c_str();
+            auto file = File::open_file(filename, File::WRITE);
+            uint64_t offSet = BufferManager::get_segment_page_id(page_id) * page_size;
+            file->read_block(offSet, page_size, reinterpret_cast<char *>(data.data()));
+            BufferFrame current_frame(page_id, this->page_size, data);
+            current_frame.exclusive = exclusive;
+            int new_position = fifo_queue.size();
+            fifo_queue.push_back(current_frame);
+            fifo_map[current_frame.page_number] = new_position;
+
+            return fifo_queue.back();
+        } else {
+
+            throw buffer_full_error{};
+
+        }
+    } 
+}
+
+
+void BufferManager::unfix_page(BufferFrame& page, bool is_dirty) {
+
+    if (fifo_map.count(page.page_number) > 0) {
+        int index = fifo_map[page.page_number];
+        fifo_queue[index].counter -= 1;
+        fifo_queue[index].dirty_bit = is_dirty;
+    }
+}
+
+std::vector<uint64_t> BufferManager::get_fifo_list() const {
+
+    vector<uint64_t> id_numbers;
+    for (BufferFrame frame: this->fifo_queue) {
+        id_numbers.push_back(frame.page_number);
+    }
+    return id_numbers;
+}
+} 

--- a/src/utils/storage/posix_file.cc
+++ b/src/utils/storage/posix_file.cc
@@ -1,0 +1,130 @@
+
+#include <fcntl.h>
+#include <stdlib.h>  // NOLINT
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+#include <cerrno>
+#include <memory>
+#include <system_error>
+
+#include "utils/storage/file.h"
+
+namespace buzzdb {
+
+namespace {
+
+[[noreturn]] void throw_errno() {
+  throw std::system_error{errno, std::system_category()};
+}
+
+}  // namespace
+
+class PosixFile : public File {
+ private:
+  Mode mode;
+  int fd;
+  size_t cached_size;
+
+  size_t read_size() {
+    struct ::stat file_stat;
+    if (::fstat(fd, &file_stat) < 0) {
+      throw_errno();
+    }
+    return file_stat.st_size;
+  }
+
+ public:
+  PosixFile(Mode mode, int fd, size_t size)
+      : mode(mode), fd(fd), cached_size(size) {}
+
+  PosixFile(const char* filename, Mode mode) : mode(mode) {
+    switch (mode) {
+      case READ:
+        fd = ::open(filename, O_RDONLY | O_SYNC);
+        break;
+      case WRITE:
+        fd = ::open(filename, O_RDWR | O_CREAT | O_SYNC, 0666);
+    }
+    if (fd < 0) {
+      throw_errno();
+    }
+    cached_size = read_size();
+  }
+
+  ~PosixFile() override {
+    // Don't check return value here, as we don't want a throwing
+    // destructor. Also, even when close() fails, the fd will always be
+    // freed (see man 2 close).
+    ::close(fd);
+  }
+
+  Mode get_mode() const override { return mode; }
+
+  size_t size() const override { return cached_size; }
+
+  void resize(size_t new_size) override {
+    if (new_size == cached_size) {
+      return;
+    }
+    if (::ftruncate(fd, new_size) < 0) {
+      throw_errno();
+    }
+    cached_size = new_size;
+  }
+
+  void read_block(size_t offset, size_t size, char* block) override {
+    size_t total_bytes_read = 0;
+    while (total_bytes_read < size) {
+      ssize_t bytes_read =
+          ::pread(fd, block + total_bytes_read, size - total_bytes_read,
+                  offset + total_bytes_read);
+      if (bytes_read == 0) {
+        // end of file, i.e. size was probably larger than the file
+        // size
+        return;
+      }
+      if (bytes_read < 0) {
+        throw_errno();
+      }
+      total_bytes_read += static_cast<size_t>(bytes_read);
+    }
+  }
+
+  void write_block(const char* block, size_t offset, size_t size) override {
+    size_t total_bytes_written = 0;
+    while (total_bytes_written < size) {
+      ssize_t bytes_written =
+          ::pwrite(fd, block + total_bytes_written, size - total_bytes_written,
+                   offset + total_bytes_written);
+      if (bytes_written == 0) {
+        // This should probably never happen. Return here to prevent
+        // an infinite loop.
+        return;
+      }
+      if (bytes_written < 0) {
+        throw_errno();
+      }
+      total_bytes_written += static_cast<size_t>(bytes_written);
+    }
+  }
+};
+
+std::unique_ptr<File> File::open_file(const char* filename, Mode mode) {
+  return std::make_unique<PosixFile>(filename, mode);
+}
+
+std::unique_ptr<File> File::make_temporary_file() {
+  char file_template[] = ".tmpfile-XXXXXX";
+  int fd = ::mkstemp(file_template);
+  if (fd < 0) {
+    throw_errno();
+  }
+  if (::unlink(file_template) < 0) {
+    ::close(fd);
+    throw_errno();
+  }
+  return std::make_unique<PosixFile>(File::WRITE, fd, 0);
+}
+
+}  // namespace buzzdb

--- a/src/utils/storage/test_file.cc
+++ b/src/utils/storage/test_file.cc
@@ -1,0 +1,56 @@
+
+#include <fcntl.h>
+#include <stdlib.h>  // NOLINT
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+#include <cerrno>
+#include <cstring>
+#include <memory>
+#include <system_error>
+
+#include "utils/storage/test_file.h"
+
+namespace buzzdb {
+
+class TestFileError : public std::exception {
+ private:
+  const char* message;
+
+ public:
+  explicit TestFileError(const char* message) : message(message) {}
+
+  ~TestFileError() override = default;
+
+  const char* what() const noexcept override { return message; }
+};
+
+File::Mode TestFile::get_mode() const { return mode; }
+
+size_t TestFile::size() const { return file_content.size(); }
+
+void TestFile::resize(size_t new_size) {
+  if (mode == READ) {
+    throw TestFileError{"trying to resize a read only file"};
+  }
+  file_content.resize(new_size);
+}
+
+void TestFile::read_block(size_t offset, size_t size, char* block) {
+  if (offset + size > file_content.size()) {
+    throw TestFileError{"trying to read past end of file"};
+  }
+  std::memcpy(block, file_content.data() + offset, size);
+}
+
+void TestFile::write_block(const char* block, size_t offset, size_t size) {
+  if (mode == READ) {
+    throw TestFileError{"trying to write to a read only file"};
+  }
+  if (offset + size > file_content.size()) {
+    throw TestFileError{"trying to write past end of file"};
+  }
+  std::memcpy(file_content.data() + offset, block, size);
+}
+
+}  // namespace buzzdb

--- a/test/unit/utils/buffermanager_test.cc
+++ b/test/unit/utils/buffermanager_test.cc
@@ -1,0 +1,128 @@
+#include <gtest/gtest.h>
+#include <algorithm>
+#include <atomic>
+#include <cstring>
+#include <memory>
+#include <random>
+#include <thread>
+#include <vector>
+
+#include "utils/buffermanager.h"
+
+namespace {
+
+TEST(BufferManagerTest, FixSingle) {
+  buzzdb::BufferManager buffer_manager{1024, 10};
+  std::vector<uint64_t> expected_values(1024 / sizeof(uint64_t), 123);
+  {
+    auto& page = buffer_manager.fix_page(1, true);
+    std::memcpy(page.get_data(), expected_values.data(), 1024);
+    buffer_manager.unfix_page(page, true);
+    EXPECT_EQ(std::vector<uint64_t>{1}, buffer_manager.get_fifo_list());
+
+  }
+  {
+    std::vector<uint64_t> values(1024 / sizeof(uint64_t));
+    auto& page = buffer_manager.fix_page(1, false);
+    std::memcpy(values.data(), page.get_data(), 1024);
+    buffer_manager.unfix_page(page, true);
+    EXPECT_EQ(std::vector<uint64_t>{1}, buffer_manager.get_fifo_list());
+    ASSERT_EQ(expected_values, values);
+  }
+}
+
+TEST(BufferManagerTest, FixEleven) {
+  buzzdb::BufferManager buffer_manager{1024, 10};
+  std::vector<uint64_t> expected_values(1024 / sizeof(uint64_t), 123);
+  {
+    auto& page1 = buffer_manager.fix_page(1, true);
+    buffer_manager.unfix_page(page1, true);
+    auto& page2 = buffer_manager.fix_page(2, true);
+    buffer_manager.unfix_page(page2, true);
+    auto& page3 = buffer_manager.fix_page(3, true);
+    buffer_manager.unfix_page(page3, true);
+    auto& page4 = buffer_manager.fix_page(4, true);
+    buffer_manager.unfix_page(page4, true);
+    auto& page5 = buffer_manager.fix_page(5, true);
+    buffer_manager.unfix_page(page5, true);
+    auto& page6 = buffer_manager.fix_page(6, true);
+    buffer_manager.unfix_page(page6, true);
+    auto& page7 = buffer_manager.fix_page(7, true);
+        buffer_manager.unfix_page(page7, true);
+
+    auto& page8 = buffer_manager.fix_page(8, true);
+        buffer_manager.unfix_page(page8, true);
+    auto& page9 = buffer_manager.fix_page(9, true);
+        buffer_manager.unfix_page(page9, true);
+    auto& page10 = buffer_manager.fix_page(10, true);
+        buffer_manager.unfix_page(page10, true);
+    auto& page11 = buffer_manager.fix_page(11, true);
+        buffer_manager.unfix_page(page11, true);
+
+    EXPECT_EQ(11, buffer_manager.get_fifo_list()[9]);
+  }
+}
+
+TEST(BufferManagerTest, PersistentRestart) {
+  auto buffer_manager = std::make_unique<buzzdb::BufferManager>(1024, 10);
+  for (uint16_t segment = 0; segment < 3; ++segment) {
+    for (uint64_t segment_page = 0; segment_page < 10; ++segment_page) {
+      uint64_t page_id = (static_cast<uint64_t>(segment) << 48) | segment_page;
+      auto& page = buffer_manager->fix_page(page_id, true);
+      uint64_t& value = *reinterpret_cast<uint64_t*>(page.get_data());
+      value = segment * 10 + segment_page;
+      buffer_manager->unfix_page(page, true);
+    }
+  }
+  buffer_manager = std::make_unique<buzzdb::BufferManager>(1024, 10);
+  for (uint16_t segment = 0; segment < 3; ++segment) {
+    for (uint64_t segment_page = 0; segment_page < 10; ++segment_page) {
+      uint64_t page_id = (static_cast<uint64_t>(segment) << 48) | segment_page;
+      auto& page = buffer_manager->fix_page(page_id, false);
+      uint64_t value = *reinterpret_cast<uint64_t*>(page.get_data());
+      buffer_manager->unfix_page(page, false);
+      EXPECT_EQ(segment * 10 + segment_page, value);
+    }
+  }
+}
+
+TEST(BufferManagerTest, FIFOEvict) {
+  buzzdb::BufferManager buffer_manager{1024, 10};
+  for (uint64_t i = 1; i < 11; ++i) {
+    auto& page = buffer_manager.fix_page(i, false);
+    buffer_manager.unfix_page(page, false);
+  }
+  {
+    std::vector<uint64_t> expected_fifo{1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
+    EXPECT_EQ(expected_fifo, buffer_manager.get_fifo_list());
+
+  }
+  {
+    auto& page = buffer_manager.fix_page(11, false);
+    buffer_manager.unfix_page(page, false);
+  }
+  {
+    std::vector<uint64_t> expected_fifo{2, 3, 4, 5, 6, 7, 8, 9, 10, 11};
+    EXPECT_EQ(expected_fifo, buffer_manager.get_fifo_list());
+
+  }
+}
+
+TEST(BufferManagerTest, BufferFull) {
+  buzzdb::BufferManager buffer_manager{1024, 10};
+  std::vector<buzzdb::BufferFrame*> pages;
+  pages.reserve(10);
+  for (uint64_t i = 1; i < 11; ++i) {
+    auto& page = buffer_manager.fix_page(i, false);
+    pages.push_back(&page);
+  }
+  EXPECT_THROW(buffer_manager.fix_page(11, false), buzzdb::buffer_full_error);
+}
+
+
+}
+
+int main(int argc, char* argv[]) {
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
Pooya Nayebi

**Buffer Manager Toy**

Created Buffer Manager Toy similar to the buffer manager from HW2. 

FIFO replacement policy

Includes page fixing, page unfixing, constructor, destructor, buffer frame class, as well as a method that returns the current buffer. For sake of simplicity, this buffer manager operates using only a FIFO queue buffer. It is also a single-threaded solution. Some test cases are inspired by those from the homework, but modified to test for FIFO compliance instead of 2Q. Also used storage modules from the HW. 