### PR TITLE
Run Length Encoding Extra Credit

### DIFF
--- a/src/include/run_length_encode_string.h
+++ b/src/include/run_length_encode_string.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include <cstdint>
+#include <iostream>
+#include <string>
+
+namespace buzzdb{
+
+std::string encode_string(std::string str);
+
+} // namespace buzzdb

--- a/src/run_length_encode_string.cc
+++ b/src/run_length_encode_string.cc
@@ -1,0 +1,39 @@
+#include <iostream>
+#include <string>
+
+namespace buzzdb {
+
+#define NULL_CHAR '\0'
+
+std::string encode_string(std::string str) {
+    if (str.size() == 0) {
+        return str;
+    }
+
+    std::string str_encoded;
+
+    size_t curr_run_size = 0;
+    char curr_run_char = NULL_CHAR;
+
+    for (size_t i = 0; i < str.size(); i++) {
+        if (curr_run_size == 0 || str[i] != curr_run_char) {
+
+            // If not just starting to encode, add current run size to back of string and end current run
+            if (curr_run_size != NULL_CHAR) str_encoded += std::to_string(curr_run_size);
+
+            // Start new run and add the new run char to back of string
+            curr_run_char = str[i];
+            curr_run_size = 0;
+            str_encoded.push_back(curr_run_char);
+        }
+        
+        curr_run_size++;
+    }
+
+    // We have reached end of string. Add the curr run size to back and return!
+    str_encoded += std::to_string(curr_run_size);
+
+    return str_encoded;
+}
+
+} // namespace buzzdb

--- a/test/unit/run_length_encode_test.cc
+++ b/test/unit/run_length_encode_test.cc
@@ -1,0 +1,54 @@
+#include <gtest/gtest.h>
+#include <algorithm>
+#include <cstdint>
+#include <cstring>
+#include <exception>
+#include <random>
+#include <utility>
+#include <vector>
+
+#include "run_length_encode_string.h"
+
+namespace {
+
+TEST(RunLengthEncodeStringTest, EmptyString) {
+  EXPECT_EQ(buzzdb::encode_string(""), "");
+}
+
+TEST(RunLengthEncodeStringTest, SingleCharOne) {
+  EXPECT_EQ(buzzdb::encode_string("A"), "A1");
+}
+
+TEST(RunLengthEncodeStringTest, SingleCharTwo) {
+  EXPECT_EQ(buzzdb::encode_string("AA"), "A2");
+}
+
+TEST(RunLengthEncodeStringTest, DoubleCharOne) {
+  EXPECT_EQ(buzzdb::encode_string("AB"), "A1B1");
+}
+
+TEST(RunLengthEncodeStringTest, DoubleCharTwo) {
+  EXPECT_EQ(buzzdb::encode_string("AABB"), "A2B2");
+}
+
+TEST(RunLengthEncodeStringTest, FlipFlop) {
+  EXPECT_EQ(buzzdb::encode_string("ABAB"), "A1B1A1B1");
+}
+
+TEST(RunLengthEncodeStringTest, LongRun) {
+  std::string long_run ("WWWWWWWWWWWWBWWWWWWWWWWWWBBBWWWWWWWWWWWWWWWWWWWWWWWWBWWWWWWWWWWWWWW");
+  std::string long_run_exp ("W12B1W12B3W24B1W14");
+  EXPECT_EQ(buzzdb::encode_string(long_run), long_run_exp);
+}
+
+TEST(RunLengthEncodeStringTest, MultipleCharLong) {
+  EXPECT_EQ(buzzdb::encode_string("aaaabbcddddd"), "a4b2c1d5");
+}
+
+
+}  // namespace
+
+int main(int argc, char *argv[]) {
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
Ayden Marshall - CS 6210

Extra Credit 2.1 "Write a toy C++ example for run length encoding compression scheme"

This implementation adds an `encode_string` method that encodes an input string using a run length encoding scheme.

I chose to implement the scheme described on [this wikipedia page](https://en.wikipedia.org/wiki/Run-length_encoding).

