### PR TITLE
Extent and Segment Example

### DIFF
--- a/src/dynamic_extent_mapping.cc
+++ b/src/dynamic_extent_mapping.cc
@@ -26,6 +26,7 @@ Segment::Segment(uint64_t initial_extent_num_disk_blocks, double growth_factor)
       growth_factor(growth_factor),
       size(0),
       power(1) {
+  // Initialize with base Extent
   Extent* extent = new Extent(initial_extent_num_disk_blocks);
   extents.push_back(extent);
 };
@@ -35,6 +36,7 @@ Segment::~Segment() {
   extents.clear();
 }
 
+/// Adds a string to the db, creates new Extents if needed
 void Segment::add_data(std::string s) {
   std::vector<char> chars(s.begin(), s.end());
 

--- a/src/dynamic_extent_mapping.cc
+++ b/src/dynamic_extent_mapping.cc
@@ -1,0 +1,63 @@
+#include "dynamic_extent_mapping.h"
+
+#include <math.h>
+
+#include <array>
+#include <vector>
+
+namespace buzzdb {
+
+DiskBlock::DiskBlock() : size(0), capacity(16){};
+
+Extent::Extent(uint64_t num_disk_blocks) : size(0), capacity(num_disk_blocks) {
+  for (uint64_t i = 0; i < num_disk_blocks; i++) {
+    DiskBlock* block = new DiskBlock();
+    disk_blocks.push_back(block);
+  }
+};
+
+Extent::~Extent() {
+  for (DiskBlock* db : disk_blocks) delete db;
+  disk_blocks.clear();
+};
+
+Segment::Segment(uint64_t initial_extent_num_disk_blocks, double growth_factor)
+    : initial_extent_num_disk_blocks(initial_extent_num_disk_blocks),
+      growth_factor(growth_factor),
+      size(0),
+      power(1) {
+  Extent* extent = new Extent(initial_extent_num_disk_blocks);
+  extents.push_back(extent);
+};
+
+Segment::~Segment() {
+  for (Extent* e : extents) delete e;
+  extents.clear();
+}
+
+void Segment::add_data(std::string s) {
+  std::vector<char> chars(s.begin(), s.end());
+
+  Extent* extent = extents[size];
+  DiskBlock* disk_block = extent->disk_blocks[extent->size];
+  for (char c : chars) {
+    disk_block->data[disk_block->size] = c;
+
+    if (++(disk_block->size) == disk_block->capacity) {
+      if (++(extent->size) == extent->capacity) {
+        size++;
+        Extent* new_extent =
+            new Extent((uint64_t)(initial_extent_num_disk_blocks *
+                                  pow(growth_factor, power++)));
+        extents.push_back(new_extent);
+
+        extent = extents[size];
+      }
+      disk_block = extent->disk_blocks[extent->size];
+    }
+  }
+};
+
+size_t Segment::get_num_extents() { return size + 1; };
+
+}  // namespace buzzdb

--- a/src/include/dynamic_extent_mapping.h
+++ b/src/include/dynamic_extent_mapping.h
@@ -1,0 +1,44 @@
+#include <array>
+#include <memory>
+#include <vector>
+
+namespace buzzdb {
+
+class DiskBlock {
+ public:
+  std::array<char, 16> data;  // each disk block stores 16 bytes of data
+  uint8_t size;
+  uint8_t capacity;
+
+  DiskBlock();
+};
+
+class Extent {
+ public:
+  std::vector<DiskBlock *> disk_blocks;
+  uint32_t size;
+  uint32_t capacity;
+
+  Extent(uint64_t num_disk_blocks);
+
+  ~Extent();
+};
+
+class Segment {
+ public:
+  std::vector<Extent *> extents;
+  uint64_t initial_extent_num_disk_blocks;
+  double growth_factor;
+  uint64_t size;
+  int power;
+
+  Segment(uint64_t initial_extent_num_disk_blocks, double growth_factor);
+
+  ~Segment();
+
+  void add_data(std::string s);
+
+  size_t get_num_extents();
+};
+
+}  // namespace buzzdb

--- a/src/include/dynamic_extent_mapping.h
+++ b/src/include/dynamic_extent_mapping.h
@@ -4,6 +4,7 @@
 
 namespace buzzdb {
 
+// Represents the lowest level of storage
 class DiskBlock {
  public:
   std::array<char, 16> data;  // each disk block stores 16 bytes of data
@@ -13,6 +14,7 @@ class DiskBlock {
   DiskBlock();
 };
 
+// Made up of contiguous DiskBlocks
 class Extent {
  public:
   std::vector<DiskBlock *> disk_blocks;
@@ -24,6 +26,7 @@ class Extent {
   ~Extent();
 };
 
+// Made up of multiple Extents, not necessarily contiguous
 class Segment {
  public:
   std::vector<Extent *> extents;

--- a/test/unit/dynamic_extent_mapping.cc
+++ b/test/unit/dynamic_extent_mapping.cc
@@ -1,0 +1,41 @@
+#include "dynamic_extent_mapping.h"
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <cstdint>
+#include <cstring>
+#include <exception>
+#include <random>
+#include <utility>
+#include <vector>
+
+namespace {
+
+TEST(DynamicExtentMappingTest, BasicTest) {
+  // Initialize a new segment with an extent with 1 disk block of size 16 bytes
+  // and a growth factor of 2
+  buzzdb::Segment segment = buzzdb::Segment(1, 2);
+
+  EXPECT_EQ(segment.get_num_extents(), 1);
+  EXPECT_EQ(segment.extents[0]->capacity, 1);
+
+  // this fills up extent #1 and creates extent #2 of size 2 disk blocks in the
+  // segment
+  segment.add_data("this is 16 bytes");
+  EXPECT_EQ(segment.get_num_extents(), 2);
+  EXPECT_EQ(segment.extents[1]->capacity, 2);
+
+  // this fills up extent #2 and creates extent #3 of size 4 disk blocks
+  segment.add_data("this is 16 bytes");
+  segment.add_data("this is 16 bytes");
+  EXPECT_EQ(segment.get_num_extents(), 3);
+  EXPECT_EQ(segment.extents[2]->capacity, 4);
+}
+
+}  // namespace
+
+int main(int argc, char *argv[]) {
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
Jack Palaia
GTID: 903487822

This example features 3 classes, DiskBlock, Extent, and Segment. Extents are made of contiguous sets of DiskBlocks, and Segments are made of Extents. The Segment class has an add_data function that allows adding strings to the db. It adds to the current extent, and if the current extent is full it will create a new extent using exponential growth.