### PR TITLE
extra credit: group 2.8 dynamic hashing

### DIFF
--- a/src/chained_hashing.cc
+++ b/src/chained_hashing.cc
@@ -1,0 +1,48 @@
+
+#include "chained_hashing/chained_hashing.h"
+
+namespace buzzdb{
+namespace utils {
+
+DynamicHashTable::DynamicHashTable(size_t num_buckets, bool uniqueKeys) : num_buckets(num_buckets),  
+                                                          uniqueKeys(uniqueKeys),
+                                                          table(num_buckets) {}
+
+std::string DynamicHashTable::get(std::string key) {
+  int keyHash = std::hash<std::string>{}(key) % num_buckets;
+  for (auto& p : table[keyHash]) {
+    if (p.first == key) {
+      return p.second;
+    }
+  }
+  return STRING_NOT_FOUND;
+}
+
+void DynamicHashTable::insert(std::string key, std::string val) {
+  int keyHash = std::hash<std::string>{}(key) % num_buckets;
+  if (uniqueKeys) {
+    for (auto& p : table[keyHash]) {
+      if (p.first == key) {
+        p.second = val;
+        return;
+      }
+    }
+  }
+  table[keyHash].push_back(std::make_pair(key, val));
+}
+
+bool DynamicHashTable::remove(std::string key) {
+  int keyHash = std::hash<std::string>{}(key) % num_buckets;
+  auto it = table[keyHash].begin();
+  while (it != table[keyHash].end()) {
+    if (it->first == key) {
+      table[keyHash].erase(it);
+      return true;
+    }
+    ++it;
+  }
+  return false;
+}
+
+}
+}

--- a/src/include/chained_hashing/chained_hashing.h
+++ b/src/include/chained_hashing/chained_hashing.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <vector>
+#include <list>
+#include <utility>
+#include <string>
+#include <functional>
+
+namespace buzzdb{
+namespace utils{
+
+const std::string STRING_NOT_FOUND = "STRING_NOT_FOUND";
+
+class DynamicHashTable {
+private:
+  const size_t num_buckets;
+  const bool uniqueKeys;
+  std::vector<std::list<std::pair<std::string, std::string>>> table;
+  
+public:
+  DynamicHashTable(size_t num_buckets, bool uniqueKeys);
+
+  std::string get(std::string key);
+
+  void insert(std::string key, std::string val);
+
+  bool remove(std::string key);
+};
+
+}
+}

--- a/test/unit/chained_hashing_test.cc
+++ b/test/unit/chained_hashing_test.cc
@@ -1,0 +1,56 @@
+
+#include <gtest/gtest.h>
+
+#include "chained_hashing/chained_hashing.h"
+
+namespace {
+
+TEST(ChainedHashingTests, Test1) {
+
+  auto table = buzzdb::utils::DynamicHashTable(3, false);
+  table.insert("abc", "123");
+  table.insert("abc", "456");
+
+  EXPECT_EQ(table.get("abc"), "123");
+  EXPECT_EQ(table.get("aaa"), buzzdb::utils::STRING_NOT_FOUND);
+}
+
+TEST(ChainedHashingTests, Test2) {
+
+  auto table = buzzdb::utils::DynamicHashTable(3, false);
+  table.insert("abc", "123");
+
+  EXPECT_EQ(table.remove("abc"), true);
+  EXPECT_EQ(table.get("abc"), buzzdb::utils::STRING_NOT_FOUND);
+  EXPECT_EQ(table.remove("abc"), false);
+}
+
+TEST(ChainedHashingTests, Test3) {
+
+  auto table = buzzdb::utils::DynamicHashTable(3, false);
+  table.insert("abc", "123");
+  table.insert("abc", "456");
+
+  EXPECT_EQ(table.get("abc"), "123");
+  EXPECT_EQ(table.remove("abc"), true);
+  EXPECT_EQ(table.get("abc"), "456");
+}
+
+TEST(ChainedHashingTests, Test4) {
+
+  auto table = buzzdb::utils::DynamicHashTable(3, true);
+  table.insert("abc", "123");
+  table.insert("abc", "456");
+
+  EXPECT_EQ(table.get("abc"), "456");
+  EXPECT_EQ(table.remove("abc"), true);
+  EXPECT_EQ(table.get("abc"), buzzdb::utils::STRING_NOT_FOUND);
+}
+
+} // namespace
+
+
+int main(int argc, char *argv[]) {
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
Yichen Zhang
GTID: 903312684

I implemented a very simple dynamic chained hashing table that allows users to specify if they would like to enforce unique keys. Any number of keys are supported, although it will become slow as more keys get hashed to the same bucket list.